### PR TITLE
Add metrics as a dep to collect analytics on microsite creation

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,8 +2,9 @@
 ## 1.2.1
 
 - Provide Tier 0 Analytics out-of-the-box:
-    - Adding `@rei/metrics` NPM package as a dependency to `package.json`.
-    - Import `@rei/metrics` into `QuickStartPageComponent.vue` and call `metrics.view()`, passing in project name.
+  - Added the `@rei/metrics` NPM package as a dependency to `package.json`.
+  - Imported `@rei/metrics` into `QuickStartPageComponent.vue` and called `metrics.view()`, passing in the project name.
+
 ## 1.2.0
 
 - Adding `--microsite` option to scaffold out QuickStart microsite front-end code and configuration.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,5 @@
 # Release notes
-## 1.2.1
+## 1.3.0
 
 - Provide Tier 0 Analytics out-of-the-box:
   - Added the `@rei/metrics` NPM package as a dependency to `package.json`.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,11 @@
 # Release notes
+## 1.2.1
 
+- Provide Tier 0 Analytics out-of-the-box:
+    - Adding `@rei/metrics` NPM package as a dependency to `package.json`.
+    - Import `@rei/metrics` into `QuickStartPageComponent.vue` and call `metrics.view()`, passing in project name.
 ## 1.2.0
+
 - Adding `--microsite` option to scaffold out QuickStart microsite front-end code and configuration.
 
 ## 1.1.1
@@ -11,15 +16,15 @@
 
 ## 1.1.0
 
-Adding repository metadata to `package.json` templates.
+- Adding repository metadata to `package.json` templates.
 
 ## 1.0.3
 
-Small change to `README.md`
+- Small change to `README.md`
 
 ## 1.0.2
 
-Adds screencast to `README.md`
+- Adds screencast to `README.md`
 
 ## 1.0.1
 
@@ -29,4 +34,4 @@ Adds screencast to `README.md`
 
 ## 1.0.0
 
-The initial release of the NPM initializer. See `README.md`.
+- The initial release of the NPM initializer. See `README.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/create-package",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/create-package",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "An NPM initializer that scaffolds new NPM packages",
   "main": "bin/main.mjs",
   "scripts": {

--- a/templates/microsite/package.json
+++ b/templates/microsite/package.json
@@ -46,6 +46,7 @@
     "@rei/ssr": "^3.0.0",
     "@rei/vite-base-config": "^3.0.0",
     "@rei/vite-plugin-alpine-uploader": "^1.0.0",
-    "vue": "^3.2.45"
+    "vue": "^3.2.45",
+    "@rei/metrics": "^3.1.26"
   }
 }

--- a/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
+++ b/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
@@ -40,7 +40,7 @@ export default {
       default: false,
     },
   },
-  created() {
+  mounted() {
     metricsPageView();
   },
   methods: {

--- a/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
+++ b/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
@@ -29,6 +29,7 @@
 </template>
 <script>
 import { CdrText, CdrImg } from '@rei/cedar';
+import metrics from '@rei/metrics';
 
 export default {
   name: 'QuickStartPageComponent',
@@ -39,12 +40,18 @@ export default {
       default: false,
     },
   },
+  created() {
+    metricsPageView();
+  },
   methods: {
 
     getMessage() {
       return this.success
         ? "🤗 Congratulations! You've successfully created your first Alpine Vue app and are passing data to it from the controller! Great job! 🎉"
         : "🤔 Almost there! Looks like we're missing the data from the controller. Check the pageData value in the #modelData element and that your props are being passed correctly.";
+    },
+    metricsPageView() {
+      metrics.view({pageName: `${__PACKAGE_NAME__}:home`});
     },
   },
 };


### PR DESCRIPTION
We would like to incorporate Tier 0 analytics as a default feature. This will enable teams to effortlessly capture some basic analytics upon microsite creation.