### PR TITLE
Call this.metricsPageView

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,7 @@
 # Release notes
+## 1.3.1
+### Bug Fixes
+- Need to call `this.metricsPageView()` in `QuickStartPageComponent.vue`.
 ## 1.3.0
 
 - Provide Tier 0 Analytics out-of-the-box:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,9 +1,13 @@
 # Release notes
+
 ## 1.3.1
+
 ### Bug Fixes
+
 - Need to call `this.metricsPageView()` in `QuickStartPageComponent.vue`.
 - Reference `__PROJECT_NAME__` (not `__PACKAGE_NAME__`).
 - Add `__PROJECT_NAME__` to eslintrc `globals` config.
+ 
 ## 1.3.0
 
 - Provide Tier 0 Analytics out-of-the-box:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 ## 1.3.1
 ### Bug Fixes
 - Need to call `this.metricsPageView()` in `QuickStartPageComponent.vue`.
+- Reference `__PROJECT_NAME__`, not `__PACKAGE_NAME__`.
 ## 1.3.0
 
 - Provide Tier 0 Analytics out-of-the-box:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,7 +2,8 @@
 ## 1.3.1
 ### Bug Fixes
 - Need to call `this.metricsPageView()` in `QuickStartPageComponent.vue`.
-- Reference `__PROJECT_NAME__`, not `__PACKAGE_NAME__`.
+- Reference `__PROJECT_NAME__` (not `__PACKAGE_NAME__`).
+- Add `__PROJECT_NAME__` to eslintrc `globals` config.
 ## 1.3.0
 
 - Provide Tier 0 Analytics out-of-the-box:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/create-package",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/create-package",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@root/walk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/create-package",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An NPM initializer that scaffolds new NPM packages",
   "main": "bin/main.mjs",
   "scripts": {

--- a/templates/microsite/.eslintrc.json
+++ b/templates/microsite/.eslintrc.json
@@ -8,6 +8,9 @@
     "mocha": true,
     "browser": true
   },
+  "globals": {
+    "__PROJECT_NAME__": true
+  },
   "overrides": [
     {
       "rules": {

--- a/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
+++ b/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
@@ -51,7 +51,7 @@ export default {
         : "🤔 Almost there! Looks like we're missing the data from the controller. Check the pageData value in the #modelData element and that your props are being passed correctly.";
     },
     metricsPageView() {
-      metrics.view({ pageName: '__PACKAGE_NAME__:home' });
+      metrics.view({ pageName: `{__PROJECT_NAME__}:home` });
     },
   },
 };

--- a/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
+++ b/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
@@ -41,7 +41,7 @@ export default {
     },
   },
   mounted() {
-    metricsPageView();
+    this.metricsPageView();
   },
   methods: {
 
@@ -51,7 +51,7 @@ export default {
         : "🤔 Almost there! Looks like we're missing the data from the controller. Check the pageData value in the #modelData element and that your props are being passed correctly.";
     },
     metricsPageView() {
-      metrics.view({pageName: `${__PACKAGE_NAME__}:home`});
+      metrics.view({ pageName: '__PACKAGE_NAME__:home' });
     },
   },
 };


### PR DESCRIPTION
- Need to call `this.metricsPageView()` in `QuickStartPageComponent.vue`.
- Reference `__PROJECT_NAME__`, not `__PACKAGE_NAME__`.