### PR TITLE
Removes nodejs_version from gitlab-ci template.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.1.1
+
+- Removes nodejs_version from gitlab-ci template. Packages will use the default node version from the extended `.gitlab-ci.yml` and can override on a per-package basis.
+
 ## 2.1.0
 
 ## Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/create-package",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/create-package",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@root/walk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/create-package",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An NPM initializer that scaffolds new NPM packages",
   "main": "dist/bin/main.mjs",
   "scripts": {

--- a/templates/vanilla/.gitlab-ci.yml
+++ b/templates/vanilla/.gitlab-ci.yml
@@ -1,5 +1,3 @@
 include:
   - project: 'rei/internal/platform-engineering/developer-platforms/ci-cd'
     file: 'npm-library.gitlab-ci.yml'
-    inputs:
-      nodejs_version: "<%&GITLAB_CI_NODE_VERSION%>"

--- a/templates/vue/.gitlab-ci.yml
+++ b/templates/vue/.gitlab-ci.yml
@@ -1,5 +1,3 @@
 include:
   - project: 'rei/internal/platform-engineering/developer-platforms/ci-cd'
     file: 'npm-library.gitlab-ci.yml'
-    inputs:
-      nodejs_version: "<%&GITLAB_CI_NODE_VERSION%>"


### PR DESCRIPTION
- Removes nodejs_version from gitlab-ci template. Packages will use the default node version from the extended `.gitlab-ci.yml` and can override on a per-package basis.