### PR TITLE
Aligning with `@rei/vite-base-config`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,7 +2,7 @@
 
 ## 2.4.1
 
-- Changing the call to `metrics.view` to accommodate the stringified `package.json.name` from `@rei/vite-base-config`.
+- Changing the call to `metrics.view` to accommodate the stringified `__PROJECT_NAME__` global variable from `@rei/vite-base-config`.
 
 ## 2.4.0
 
@@ -11,7 +11,7 @@
 
 ## 2.3.1
 
-- Update the metrics call using the \__PROJECT_NAME_ global.
+- Update the metrics call using the `__PROJECT_NAME__` global.
 - Remove extraneous quotes in GL configs.
 - Auto-fix sec vuln reported by `npm audit`.
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,19 +1,23 @@
 # Release Notes
 
+## 2.4.1
+
+- Changing the call to `metrics.view` to accommodate the stringified `package.json.name` from `@rei/vite-base-config`.
+
 ## 2.4.0
 
-- Setting depedency versions using variables defined in config. This synchronizes dep versions between templates and reduces the number of manual edits needed.
-- Removes `@rei/cov-stats` since its integrated into GitLab CI pipelines now.
+- Setting dependency versions using variables defined in config. This synchronizes dep versions between templates and reduces the number of manual edits needed.
+- Removes `@rei/cov-stats` since it's integrated into GitLab CI pipelines now.
 
 ## 2.3.1
 
-- Update the metrics call using the __PROJECT_NAME_ global.
+- Update the metrics call using the \__PROJECT_NAME_ global.
 - Remove extraneous quotes in GL configs.
 - Auto-fix sec vuln reported by `npm audit`.
 
 ## 2.3.0
 
-- Removing @rei/cov-stats from vanilla and vue templates. This is automatically run in the GL pipeline.
+- Removing `@rei/cov-stats` from vanilla and vue templates. This is automatically run in the GL pipeline.
 - Removing node versions in .env. Defaulting to LTS version in packages now to keep inline with GL pipeline set to LTS.
 
 ## 2.2.1
@@ -23,7 +27,7 @@
 
 ## 2.2.0
 
-- Extracted types to designated file
+- Extracted types to a designated file
 - Sorted templatized `package.json`s
 - Bumped various deps in templates
 - Closes #15 where `.npmrc` was not being packed in the tarball when published to the registry. We pack a `npmrc` file instead of `.npmrc` and rename it to `.npmrc` at runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/create-package",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/create-package",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@root/walk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/create-package",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "An NPM initializer that scaffolds new NPM packages",
   "bugs": {
     "url": "https://github.com/rei/create-package/issues"

--- a/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
+++ b/templates/microsite/src/main/js/components/QuickStartPageComponent/QuickStartPageComponent.vue
@@ -51,7 +51,7 @@ export default {
         : "🤔 Almost there! Looks like we're missing the data from the controller. Check the pageData value in the #modelData element and that your props are being passed correctly.";
     },
     metricsPageView() {
-      metrics.view({ pageName: '__PROJECT_NAME__:home' });
+      metrics.view({ pageName: `${__PROJECT_NAME__.split('"').join('')}:home` });
     },
   },
 };

--- a/templates/microsite/src/main/js/types/shared.types.mts
+++ b/templates/microsite/src/main/js/types/shared.types.mts
@@ -1,3 +1,9 @@
 export interface GenericStringKeyValueObject {
   [index: string]: string;
 }
+
+declare global {
+  // This global variable is declared in @rei/vite-base-config
+  // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle
+  const __PROJECT_NAME__: string;
+}


### PR DESCRIPTION
- Changing the call to `metrics.view` to accommodate the stringified `__PROJECT_NAME__` global variable from `@rei/vite-base-config`.